### PR TITLE
Extending sample configuration for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ grunt.initConfig({
             composerLocation: '/usr/bin/composer'
         },
         some_target: {
+            options : {
+                flags: ['arg'],
+                cwd: 'packages/build'
+            }
         }
     }
 })


### PR DESCRIPTION
I had a hard time recognizing (maybe its just my stupidity) that inside the "some_target"-level there is a second "options"-level necessary.